### PR TITLE
NCSD-398: Azure search app settings fix

### DIFF
--- a/Resources/template.json
+++ b/Resources/template.json
@@ -249,11 +249,11 @@
               },
               {
                 "name": "SearchServiceSettings__ApiUrl",
-                "value": "[concat('https://', parameters('searchName'), '.windows.net/indexes/', parameters('searchIndex'), '/docs/search')]"
+                "value": "[concat('https://', parameters('searchName'), '.search.windows.net/indexes/', parameters('searchIndex'), '/docs/search')]"
               },
               {
                 "name": "SearchServiceSettings__ApiVersion",
-                "value": "11/11/2017"
+                "value": "2017-11-11"
               },
               {
                 "name": "SearchServiceSettings__QueryKey",


### PR DESCRIPTION
Fixed app settings (SearchServiceSettings__ApiUrl and SearchServiceSettings__ApiVersion) so that Azure Search calls work